### PR TITLE
Support Django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,7 @@ matrix:
     - python: "2.6"
       env: DJANGO="django>=1.7.0,<1.8.0"
     - python: "2.6"
-      env: DJANGO="django>=1.7.0,<1.8.0"
-    - python: "2.6"
-      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+      env: DJANGO="django>=1.8.0,<1.9.0"
     - python: "2.6"
       env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 
 env:
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
+  - DJANGO="django>=1.8.0,<1.9.0"
   - DJANGO="django>=1.7.0,<1.8.0"
   - DJANGO="django>=1.6.0,<1.7.0"
   - DJANGO="django>=1.5.0,<1.6.0"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=['timezone_utils'],
     install_requires=[
         'pytz',
-        'django>=1.4,<1.8'
+        'django>=1.4,<1.9'
     ],
     zip_safe=False,
     platforms='any',

--- a/tests/test_valid_timezonefield.py
+++ b/tests/test_valid_timezonefield.py
@@ -48,6 +48,7 @@ class TimeZoneFieldTestCase(TestCase):
         location = LocationTimeZone.objects.get(timezone='US/Eastern')
         with self.assertRaises(ValidationError):
             location.timezone = 'Bad/Timezone'
+            location.save()
 
     def test_location_is_equals_correct_timezone(self):
         """Location should return a datetime.tzinfo instance, not a string."""

--- a/timezone_utils/fields.py
+++ b/timezone_utils/fields.py
@@ -8,12 +8,13 @@ import pytz
 import warnings
 
 # Django
+import django
 try:
     from django.core import checks
 except ImportError:     # pragma: no cover
     pass
 from django.core.exceptions import ValidationError
-from django.db.models import SubfieldBase
+from django.db import models
 from django.db.models.fields import DateTimeField, CharField
 from django.utils.six import with_metaclass
 from django.utils.timezone import get_default_timezone, is_naive, make_aware
@@ -22,13 +23,17 @@ from django.utils.translation import ugettext_lazy as _
 # App
 from timezone_utils import forms
 
+
+TimeZoneFieldBase = type if django.VERSION >= (1, 8) else models.SubfieldBase
+
+
 __all__ = ('TimeZoneField', 'LinkedTZDateTimeField')
 
 
 # ==============================================================================
 # MODEL FIELDS
 # ==============================================================================
-class TimeZoneField(with_metaclass(SubfieldBase, CharField)):
+class TimeZoneField(with_metaclass(TimeZoneFieldBase, CharField)):
     # Enforce the minimum length of max_length to be the length of the longest
     #   pytz timezone string
     MIN_LENGTH = max(map(len, pytz.all_timezones))
@@ -58,18 +63,31 @@ class TimeZoneField(with_metaclass(SubfieldBase, CharField)):
 
         super(TimeZoneField, self).__init__(*args, **kwargs)
 
+    def validate(self, value, model_instance):
+        super(TimeZoneField, self).validate(self.get_prep_value(value), model_instance)
+        # Check perceable
+        self.to_python(value)
+
+    def run_validators(self, value):
+        super(TimeZoneField, self).run_validators(self.get_prep_value(value))
+
     def get_prep_value(self, value):
         """Converts timezone instances to strings for db storage."""
 
+        value = super(TimeZoneField, self).get_prep_value(value)
         if isinstance(value, tzinfo):
             return value.zone
+        return value
+
+    def from_db_value(self, value, expression, connection, context):
+        if value:
+            value = self.to_python(value)
         return value
 
     def to_python(self, value):
         """Returns a datetime.tzinfo instance for the value."""
 
         value = super(TimeZoneField, self).to_python(value)
-
         if not value:
             return value
 
@@ -190,13 +208,18 @@ class TimeZoneField(with_metaclass(SubfieldBase, CharField)):
         return []
 
 
-class LinkedTZDateTimeField(with_metaclass(SubfieldBase, DateTimeField)):
+class LinkedTZDateTimeField(with_metaclass(TimeZoneFieldBase, DateTimeField)):
     def __init__(self, *args, **kwargs):
         self.populate_from = kwargs.pop('populate_from', None)
         self.time_override = kwargs.pop('time_override', None)
         self.timezone = get_default_timezone()
 
         super(LinkedTZDateTimeField, self).__init__(*args, **kwargs)
+
+    def from_db_value(self, value, expression, connection, context):
+        if value:
+            value = self.to_python(value)
+        return value
 
     def to_python(self, value):
         """Convert the value to the appropriate timezone."""

--- a/timezone_utils/forms.py
+++ b/timezone_utils/forms.py
@@ -8,6 +8,7 @@ import pytz
 # Django
 from django.core.exceptions import ValidationError
 from django.forms import CharField
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 __all__ = ('TimeZoneField', )
@@ -20,6 +21,9 @@ class TimeZoneField(CharField):
     default_error_messages = {
         'invalid': _("'%(value)s' is not a valid time zone."),
     }
+
+    def run_validators(self, value):
+        return super(TimeZoneField, self).run_validators(force_text(value))
 
     def to_python(self, value):
         value = super(TimeZoneField, self).to_python(value)


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/howto/custom-model-fields/

> Historically, Django provided a metaclass called SubfieldBase which always called to_python() on assignment. This did not play nicely with custom database transformations, aggregation, or values queries, so it has been replaced with from_db_value().