### PR TITLE
Add minimal Tox config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/locale/
 build/
 .idea
 .coverage
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist =
+    py{27,34,35,36}-dj1.{8,11}
+    py{34,35,36}-dj2.0
+
+[testenv]
+deps =
+    dj1.8: Django ~=1.8.0
+    dj1.11: Django ~=1.11.0
+    dj2.0: Django ~=2.0.0
+commands =
+    {envpython} run_tests.py


### PR DESCRIPTION
This should make it more convenient to locally test the supported Python / Django versions.