### PR TITLE
Fix choices attribute Django check for empty values

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -84,6 +84,26 @@ class LocationTimeZoneChoices(models.Model):
     )
 
 
+class LocationTimeZoneChoicesWithEmpty(models.Model):
+    timezone = TimeZoneField(
+        verbose_name=_('timezone'),
+        max_length=64,
+        null=True,
+        blank=True,
+        choices=[('', 'No time zone')] + list(PRETTY_ALL_TIMEZONES_CHOICES),
+    )
+
+
+class LocationTimeZoneBadChoices(models.Model):
+    timezone = TimeZoneField(
+        verbose_name=_('timezone'),
+        max_length=64,
+        null=True,
+        blank=True,
+        choices=[('Bad/Worse', 'Bad Choice')],
+    )
+
+
 class TZWithGoodStringDefault(models.Model):
     """Test should validate that"""
     timezone = TimeZoneField(

--- a/timezone_utils/fields.py
+++ b/timezone_utils/fields.py
@@ -195,10 +195,11 @@ class TimeZoneField(CharField):
                                     )
                                 })
 
-                            # Return the warning
-                            return [
-                                checks.Warning(**warning_params)
-                            ]
+                                # Return the warning
+                                return [
+                                    checks.Warning(**warning_params)
+                                ]
+
                 elif option_key not in pytz.all_timezones:
                     # Make sure we don't raise this error on empty
                     #   values
@@ -211,10 +212,10 @@ class TimeZoneField(CharField):
                             )
                         })
 
-                    # Return the warning
-                    return [
-                        checks.Warning(**warning_params)
-                    ]
+                        # Return the warning
+                        return [
+                            checks.Warning(**warning_params)
+                        ]
 
         # When no error, return an empty list
         return []


### PR DESCRIPTION
This was accidentally producing a warning for empty `choices` values, rather than skipping them. 