### PR TITLE
Add support for Django 2.1 and drop support for EOL versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,69 +1,53 @@
-language:
-  python
-
-python:
-  - "2.7"
-  # https://docs.djangoproject.com/en/dev/releases/1.8/#python-compatibility
-  # Due to the end of upstream support for Python 3.2 in February 2016, we
-  # won’t test Django 1.8.x on Python 3.2 after the end of 2016.
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "nightly"
-
-env:
-  - DJANGO="https://github.com/django/django/archive/master.tar.gz"
-  - DJANGO="django>=2.0,<2.1"
-  - DJANGO="django>=1.10,<1.11"
-  - DJANGO="django>=1.9,<1.10"
-  - DJANGO="django>=1.8,<1.9"
-
+sudo: false
+language: python
+cache:
+  pip: true
+  directories:
+  - $TRAVIS_BUILD_DIR/.tox
+matrix:
+  fast_finish: true
+  include:
+  - env: TOX_ENV=py27-dj111
+    python: 2.7
+  - env: TOX_ENV=py34-dj111
+    python: 3.4
+  - env: TOX_ENV=py35-dj111
+    python: 3.5
+  - env: TOX_ENV=py36-dj111
+    python: 3.6
+  - env: TOX_ENV=py34-dj20
+    python: 3.4
+  - env: TOX_ENV=py35-dj20
+    python: 3.5
+  - env: TOX_ENV=py36-dj20
+    python: 3.6
+  - env: TOX_ENV=py37-dj20
+    sudo: true  # TODO Remove when supported
+    dist: xenial
+    python: 3.7
+  - env: TOX_ENV=py35-dj21
+    python: 3.5
+  - env: TOX_ENV=py36-dj21
+    python: 3.6
+  - env: TOX_ENV=py37-dj21
+    sudo: true  # TODO Remove when supported
+    dist: xenial
+    python: 3.7
+  - env: TOX_ENV=py35-djmaster
+    python: 3.5
+  - env: TOX_ENV=py36-djmaster
+    python: 3.6
+  - env: TOX_ENV=py37-djmaster
+    sudo: true  # TODO Remove when supported
+    dist: xenial
+    python: 3.7
+  allow_failures:
+  - env: TOX_ENV=py35-djmaster
+  - env: TOX_ENV=py36-djmaster
+  - env: TOX_ENV=py37-djmaster
 install:
-  - travis_retry pip install $DJANGO
-  - travis_retry pip install pytz
-  - travis_retry pip install coverage==3.7.1  # required by python 3.2
-  - travis_retry pip install coveralls
-  - travis_retry pip install django-discover-runner
-
+- pip install -U pip setuptools tox wheel
 script:
-  - coverage run --source=timezone_utils run_tests.py
-  - coverage report
-
-after_success: coveralls
-
+- tox -e "${TOX_ENV}"
 notifications:
   email: false
-
-matrix:
-  exclude:
-    # https://docs.djangoproject.com/en/dev/releases/1.9/#python-compatibility
-    # Django 1.9 requires Python 2.7, 3.4, or 3.5
-    - python: "3.2"
-      env: DJANGO="django>=1.9,<1.10"
-    - python: "3.3"
-      env: DJANGO="django>=1.9,<1.10"
-    # https://docs.djangoproject.com/en/dev/releases/1.10/#python-compatibility
-    # Django 1.10 requires Python 2.7, 3.4, or 3.5
-    - python: "3.2"
-      env: DJANGO="django>=1.10,<1.11"
-    - python: "3.3"
-      env: DJANGO="django>=1.10,<1.11"
-    # https://docs.djangoproject.com/en/dev/releases/1.11/#python-compatibility
-    # Django 1.11 requires Python 2.7, 3.4, or 3.5.
-    # The Django 1.11.x series is the last to support Python 2.
-    # The next major release, Django 2.0, will only support Python 3.5+
-    - python: "2.7"
-      env: DJANGO="django>=2.0,<2.1"
-    - python: "3.2"
-      env: DJANGO="django>=2.0,<2.1"
-    - python: "3.3"
-      env: DJANGO="django>=2.0,<2.1"
-    - python: "3.2"
-      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
-    - python: "3.3"
-      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
-  allow_failures:
-    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
-    - python: "nightly"
-  fast_finish: true

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,7 @@ Contributors
 
 Changelog
 ---------
+- 0.12 Add support for Django 2.1. Support Python 3.7. Drop support for Django 1.8.
 - 0.11 Removed reference to django.db.models.fields.subclassing.SubfieldBase, which means that only Django 1.8+ is now supported. Removed support for Python versions < 2.6. The Django 1.6 series was the last to support Python 2.6. Added testing support for Django 1.10. Changed development status from Beta to Production/Stable.
 - 0.10 Added testing support for Python 3.5 and Django 1.9.
 - 0.9 Corrected a bug to where ``time_override`` caused invalid date due to not converting to the correct timezone first. Refactored conversion code. Added testing support for Django 1.8. Removed Django from setup requirements - the onus of having a supported version of Django is on the developer.

--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,7 @@ Contributors
 * `Michael Barr <http://github.com/michaeljohnbarr>`_
 * `Kosei Kitahara <https://github.com/Surgo>`_
 * `Alex Kamedov <https://github.com/alekam>`_
+* `Pi Delport <https://github.com/pjdelport>`_
 
 Changelog
 ---------

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,7 +7,6 @@ import pytz
 import sys
 
 # Django
-from django import VERSION
 from django.conf import settings
 from django.core.management import execute_from_command_line
 from django.utils import timezone
@@ -21,11 +20,6 @@ INSTALLED_APPS = [
 
 if not settings.configured:
     test_runners_args = {}
-    if VERSION < (1, 6):    # pragma: no cover
-        INSTALLED_APPS.append('discover_runner')
-        test_runners_args = {
-            'TEST_RUNNER': 'discover_runner.DiscoverRunner',
-        }
     settings.configure(
         DATABASES={
             'default': {
@@ -50,7 +44,6 @@ if not settings.configured:
             datetime(2014, 1, 1), pytz.timezone('UTC')
         ),
         # SILENCED_SYSTEM_CHECKS=['1_7.W001'],
-        **test_runners_args
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=['timezone_utils'],
     install_requires=[
         'pytz',
-        'django>=1.8'
+        'django>=1.11'
     ],
     zip_safe=False,
     platforms='any',
@@ -37,10 +37,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Database',
         'Topic :: Software Development :: Libraries',
     ],

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,11 @@ setup(
     include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
+        'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',

--- a/timezone_utils/__init__.py
+++ b/timezone_utils/__init__.py
@@ -1,2 +1,2 @@
-__version__ = (0, 11)
+__version__ = (0, 12)
 VERSION = '.'.join(map(str, __version__))

--- a/timezone_utils/fields.py
+++ b/timezone_utils/fields.py
@@ -93,7 +93,7 @@ class TimeZoneField(CharField):
             the reverse of get_prep_value(). - New in Django 1.8
             """
             if value:
-                value = self.to_python(value)
+                return self.to_python(value)
             return value
     else:
         def from_db_value(self, value, expression, connection):
@@ -102,7 +102,7 @@ class TimeZoneField(CharField):
             the reverse of get_prep_value(). - New in Django 1.8
             """
             if value:
-                value = self.to_python(value)
+                return self.to_python(value)
             return value
 
     def to_python(self, value):
@@ -242,12 +242,26 @@ class LinkedTZDateTimeField(DateTimeField):
 
         super(LinkedTZDateTimeField, self).__init__(*args, **kwargs)
 
-    def from_db_value(self, value, expression, connection, context):
-        # pylint: disable=W0613
-        if value:
-            value = self.to_python(value)
-
-        return value
+    # Django 2.0 updates the signature of from_db_value.
+    # https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value
+    if django.VERSION < (2,):
+        def from_db_value(self, value, expression, connection, context):    # noqa
+            """
+            Converts a value as returned by the database to a Python object. It is
+            the reverse of get_prep_value(). - New in Django 1.8
+            """
+            if value:
+                return self.to_python(value)
+            return value
+    else:
+        def from_db_value(self, value, expression, connection):
+            """
+            Converts a value as returned by the database to a Python object. It is
+            the reverse of get_prep_value(). - New in Django 1.8
+            """
+            if value:
+                return self.to_python(value)
+            return value
 
     def to_python(self, value):
         """Convert the value to the appropriate timezone."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,27 @@
-# tox (https://tox.readthedocs.io/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
+skipsdist = true
+skip_missing_interpreters = true
 envlist =
-    py{27,34,35,36}-dj1.{8,11}
-    py{34,35,36}-dj2.0
-
+  py{27,34,35,36}-dj111,
+  py{34,35,36,37}-dj20,
+  py{35,36,37}-dj21,
+  py{35,36,37}-djmaster
 [testenv]
+basepython =
+  py27: python2.7
+  py34: python3.4
+  py35: python3.5
+  py36: python3.6
+  py37: python3.7
 deps =
-    dj1.8: Django ~=1.8.0
-    dj1.11: Django ~=1.11.0
-    dj2.0: Django ~=2.0.0
+  dj111: Django>=1.11,<2.0
+  dj20: Django>=2.0,<2.1
+  dj21: Django>=2.1,<2.2
+  djmaster: https://github.com/django/django/archive/master.tar.gz
+  py37-dj21: codecov
+  pytz
+  django-discover-runner
+  coverage
 commands =
-    {envpython} run_tests.py
+  coverage run --source=timezone_utils run_tests.py
+  py37-dj21: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ deps =
   djmaster: https://github.com/django/django/archive/master.tar.gz
   py37-dj21: codecov
   pytz
-  django-discover-runner
   coverage
 commands =
   coverage run --source=timezone_utils run_tests.py


### PR DESCRIPTION
- Add support for Django 2.1
- Add support for [Python 3.7](https://docs.djangoproject.com/en/2.1/faq/install/#what-python-version-can-i-use-with-django)
- Drop support for [Django 1.8](https://www.djangoproject.com/download/#supported-versions)
- Use tox to run tests and env matrix.